### PR TITLE
fix: running selflare not working

### DIFF
--- a/.changeset/Add-shebang.md
+++ b/.changeset/Add-shebang.md
@@ -1,0 +1,5 @@
+---
+"selflare": patch
+---
+
+Add shebang to the installed "binary" to make Selflare executable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,3 +35,9 @@ jobs:
 
             - name: Test
               run: pnpm test
+
+            - name: Test installation
+              run: |
+                  pnpm i -g .
+                  # Just execution the binary and letting it exit successfully is enough
+                  selflare --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,6 @@ jobs:
 
             - name: Test installation
               run: |
-                  pnpm i -g .
+                  pnpm link -g
                   # Just execution the binary and letting it exit successfully is enough
                   selflare --version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "selflare",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Compile Cloudflare Workers to Cap'n Proto and deliver them as Docker images.",
 	"keywords": [
 		"cloudflare",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import type { Argv } from "yargs";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";


### PR DESCRIPTION
Fixes the following error by [adding a shebang ](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#bin), because Linux doesn't know how to execute the file:

```
 > [worker compile 5/5] RUN selflare compile --script index.js:
line 1: use strict: not found
0.615 /usr/local/bin/selflare: line 2: var: not found
0.615 /usr/local/bin/selflare: line 3: var: not found
0.615 /usr/local/bin/selflare: line 4: var: not found
0.616 /usr/local/bin/selflare: line 5: var: not found
0.616 /usr/local/bin/selflare: line 6: var: not found
0.616 /usr/local/bin/selflare: line 7: var: not found
0.616 /usr/local/bin/selflare: line 8: syntax error: unexpected "("
```